### PR TITLE
Add improved commit classification, per-module breakdown, and DDEV support

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,9 @@
+name: drupal-core-metrics
+type: php
+docroot: ""
+php_version: "8.3"
+webserver_type: nginx-fpm
+database:
+  type: mariadb
+  version: "10.11"
+disable_settings_management: true

--- a/README.md
+++ b/README.md
@@ -36,9 +36,34 @@ Distinct extension points in Drupal. A larger surface may correlate with a steep
 
 ## Running locally
 
-**Prerequisites:** PHP 8.1+, Python 3, Composer
+### Option 1: DDEV (Recommended)
 
-### Regenerating data
+**Prerequisites:** [DDEV](https://ddev.readthedocs.io/en/stable/) installed
+
+```bash
+# 1. Clone and start DDEV
+git clone https://github.com/podarok/drupal-core-metrics.git
+cd drupal-core-metrics
+ddev start
+
+# 2. Install PHP dependencies
+ddev composer install
+
+# 3. Run analysis (15-30 min)
+ddev exec "cd /var/www/html && python3 scripts/analyze.py"
+
+# 4. View dashboard
+ddev launch
+```
+
+For verbose output during analysis:
+```bash
+ddev exec "cd /var/www/html && DEBUG=1 python3 scripts/analyze.py"
+```
+
+### Option 2: Manual Setup
+
+**Prerequisites:** PHP 8.1+, Python 3, Composer
 
 ```bash
 composer install              # Install dependencies
@@ -47,7 +72,7 @@ python3 scripts/analyze.py    # Run analysis (15-30 min)
 
 This generates `data.json`. The `index.html` file is static and does not need to be regenerated.
 
-### Viewing the dashboard
+### Viewing the dashboard (manual)
 
 The dashboard loads data via `fetch()`, which requires an HTTP server (browsers block this for local files). Start a simple server:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Distinct extension points in Drupal. A larger surface may correlate with a steep
 
 ```bash
 # 1. Clone and start DDEV
-git clone https://github.com/podarok/drupal-core-metrics.git
+git clone https://github.com/dbuytaert/drupal-core-metrics.git
 cd drupal-core-metrics
 ddev start
 

--- a/index.html
+++ b/index.html
@@ -487,7 +487,7 @@
 
             section.innerHTML = `
                 <h2>Recent commits</h2>
-                <p class="section-subtitle">Commits that changed code quality metrics. Green = improved, red = worsened.</p>
+                <p class="section-subtitle">Commits that changed code quality metrics. Green = improved, red = worsened. Type is classified from commit messages: Conventional Commits prefixes, Drupal.org issue descriptions, or keywords like "add" (Feature), "fix" (Bug), "refactor" (Maintenance).</p>
                 <table class="hotspots-table">
                     <thead><tr><th>Commit</th><th>Date</th><th>Type</th><th>Message</th><th>LOC Δ</th><th>CCN Δ</th><th>MI Δ</th><th>Anti-patterns Δ</th></tr></thead>
                     <tbody id="commits-tbody">${initialRows}</tbody>
@@ -795,6 +795,7 @@
             section.innerHTML = `<h2>Features vs tasks vs bugs</h2>
                 <p class="section-subtitle">Tasks include both maintenance work (documentation, tests, CI, refactoring) and innovation (smaller enhancements, new feature follow-ups). Healthy mature projects allocate 20-40% to features; a lower ratio reflects a focus on stability and reliability, while below 20% introduces the risk of becoming obsolete.</p>
                 <p class="section-subtitle">Note: these numbers undercount feature development because much of it happens across multiple commits (classified as tasks or bug fixes) and in external repositories before experimental modules are added to Core. Drupal's architecture also encourages innovation in contributed modules, so Core's ratio tells only part of the story.</p>
+                <p class="section-subtitle">Commits are classified using <a href="https://www.conventionalcommits.org/">Conventional Commits</a> format (<code>feat:</code>, <code>fix:</code>), Drupal.org issue references (<code>Issue #XXX: Add...</code>), and keyword detection (<code>add</code>, <code>fix</code>, <code>refactor</code>, etc.).</p>
                 <div class="chart-container"><canvas></canvas></div>`;
             container.appendChild(section);
 
@@ -872,6 +873,59 @@
                     }
                 }
             });
+        }
+
+        function renderPerModule(container, perModule) {
+            if (!perModule || perModule.length < 2) return;
+
+            const section = document.createElement('div');
+            section.className = 'card';
+            const initialShow = 20;
+            let expanded = false;
+
+            const makeRow = (mod, index) => {
+                const ccnClass = mod.ccn > 10 ? 'metric-bad' : mod.ccn > 6 ? 'metric-warning' : 'metric-good';
+                const miClass = mod.mi < 65 ? 'metric-bad' : mod.mi < 85 ? 'metric-warning' : 'metric-good';
+                return `
+                    <tr>
+                        <td>${index + 1}</td>
+                        <td><code>${escapeHtml(mod.name)}</code></td>
+                        <td>${mod.loc.toLocaleString()}</td>
+                        <td class="${ccnClass}">${mod.ccn.toFixed(1)}</td>
+                        <td class="${miClass}">${mod.mi.toFixed(1)}</td>
+                        <td>${mod.antipatterns}</td>
+                    </tr>
+                `;
+            };
+
+            const initialRows = perModule.slice(0, initialShow).map(makeRow).join('');
+            const hasMore = perModule.length > initialShow;
+            const toggleButton = hasMore ? `<button id="toggle-modules" class="toggle-button">Show all ${perModule.length} modules</button>` : '';
+
+            section.innerHTML = `
+                <h2>Per-module breakdown</h2>
+                <p class="section-subtitle">Metrics for each core module (core/modules/*). Sorted by LOC descending. Identifies which modules have the most code and potential complexity hotspots. CCN &gt;10 (red) and MI &lt;65 (red) indicate modules that may benefit from refactoring.</p>
+                <table class="hotspots-table">
+                    <thead><tr><th>#</th><th>Module</th><th>LOC</th><th>CCN (avg)</th><th>MI (avg)</th><th>Anti-patterns</th></tr></thead>
+                    <tbody id="modules-tbody">${initialRows}</tbody>
+                </table>
+                ${toggleButton}
+            `;
+            container.appendChild(section);
+
+            if (hasMore) {
+                document.getElementById('toggle-modules').addEventListener('click', function() {
+                    const tableBody = document.getElementById('modules-tbody');
+                    expanded = !expanded;
+                    if (expanded) {
+                        tableBody.innerHTML = perModule.map(makeRow).join('');
+                        this.textContent = 'Show fewer modules';
+                    } else {
+                        tableBody.innerHTML = perModule.slice(0, initialShow).map(makeRow).join('');
+                        this.textContent = `Show all ${perModule.length} modules`;
+                    }
+                });
+            }
         }
 
         function renderSurfaceAreaReference(container, snapshots) {
@@ -956,6 +1010,7 @@
             createCommitsPerYearChart(container, data.commitsPerYear);
             createCommitsPerMonthChart(container, data.commitsMonthly);
             createCommitTypeDistributionChart(container, data.commitsMonthly);
+            renderPerModule(container, data.perModule);
             renderSurfaceAreaReference(container, data.snapshots);
         }
 

--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -646,12 +646,13 @@ def main():
     per_module_data = []
     if code == 0 and head_commit.strip():
         current_date = datetime.now().strftime("%Y-%m")
-        # Only add if not already covered by the last snapshot
-        if not snapshots or snapshots[-1]["date"] != current_date:
-            result = analyze_version(drupal_dir, head_commit.strip(), current_date, output_dir,
-                                     collect_per_module=True)
-            if result:
-                per_module_data = result.pop("perModule", [])
+        # Always collect per-module data from HEAD
+        result = analyze_version(drupal_dir, head_commit.strip(), current_date, output_dir,
+                                 collect_per_module=True)
+        if result:
+            per_module_data = result.pop("perModule", [])
+            # Only add snapshot if not already covered by the last one
+            if not snapshots or snapshots[-1]["date"] != current_date:
                 snapshots.append(result)
 
     # Cleanup work directory


### PR DESCRIPTION
## Summary

This PR enhances the Drupal Core Metrics dashboard with improved commit classification, per-module breakdown, and local development support.

## Changes

### 1. Enhanced Commit Classification

<details>
<summary>📊 Before vs After</summary>

| Before | After |
|--------|-------|
| Simple prefix matching (`fix:`, `feat:`) | Full Conventional Commits spec + Drupal.org patterns |
| Many commits classified as "Unknown" | Intelligent keyword fallback reduces unknowns |

</details>

**New classification approach (3-tier):**

1. **Conventional Commits** - `feat:`, `fix:`, `chore:`, etc. with optional scope
2. **Drupal.org Issue parsing** - Extracts description from `Issue #XXX by authors: Add something` and recursively classifies
3. **Keyword fallback** - Detects `add`, `fix`, `refactor`, etc. in message text

```python
# Example: "Issue #3556987 by user: Add a recursive sort-by"
# → Extracts "Add a recursive sort-by" → Matches "add " → Returns "Feature"
```

### 2. Per-Module Breakdown

New section showing metrics for each `core/modules/*` directory:

| Column | Description |
|--------|-------------|
| Module | Module name |
| LOC | Lines of code |
| CCN (avg) | Cyclomatic complexity (red >10, yellow >6) |
| MI (avg) | Maintainability index (red <65, yellow <85) |
| Anti-patterns | Total anti-pattern count |

### 3. Debug Mode

```bash
DEBUG=1 python3 scripts/analyze.py
```

Outputs detailed logging for troubleshooting analysis issues.

### 4. DDEV Configuration

Added `.ddev/config.yaml` for easy local development:

```bash
ddev start && ddev composer install
ddev exec "cd /var/www/html && python3 scripts/analyze.py"
ddev launch
```

### 5. Updated Documentation

- README now includes DDEV setup as recommended option
- Dashboard explanations updated to describe classification methodology
- Per-module section explains threshold colors

## Files Changed

```
.ddev/config.yaml   # New: DDEV configuration
README.md           # Updated: DDEV setup guide
index.html          # Updated: Per-module table + explanations
scripts/analyze.py  # Updated: Classification + per-module + debug
```

## Testing

- [x] Ran full analysis with `DEBUG=1`
- [x] Verified per-module breakdown appears in dashboard
- [x] Tested commit classification with Drupal.org issue format
- [x] Confirmed DDEV setup works from scratch